### PR TITLE
Initial API proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,162 @@
-# ockham.net.convert
-Succinct but flexible data conversions for extended primitive data types
+# Ockham.Convert
+Succinct but flexible data conversions for extended primitive data types. Part of the [Ockham.NET](https://github.com/ockham-net/ockham.net) project.
+
+## The Problem
+> Every Ockham component should solve a clear problem that is not solved in the .NET BCL, or in the particular libraries it is meant to augment. 
+
+The utilities in this library provide robust, configurable data inspection and conversion utilities. These are particularly useful when deserializing from databases or other external sources, and when working with dynamic data. For more detail, see [Purpose](#purpose).
+
+# The API
+
+The most basic operation is to convert from a value of an unknown type (`object`) to a specific type, using either generic syntax (when you know the target type at compile time) or non-generic sytax (when you need to specify the target type at runtime):
+
+```C#
+using Ockham.Data;
+
+     T Convert.To<T>(object);
+object Convert.To(object, Type);
+```
+
+This intuitively works for `DBNull`, `Guid`, `Timespan`, `bool`, `Nullable<T>`, and all enums (even nullables of enums!), and will automatically use `IConvertible` and/or user defined conversion operators where applicable. 
+
+Subtleties of these conversions can be controlled with the `ConvertOptions` class, described in more detail below:
+
+```C#
+object Convert.To(object, Type, ConvertOptions);
+     T Convert.To<T>(object, ConvertOptions);
+```
+
+Several type-specific overloads are also defined for convenience, which use the `ConvertOptions.Default` settings:
+
+```C#
+  bool Convert.ToBool(object)
+  Guid Convert.ToGuid(object)
+   int Convert.ToInt(object)
+  long Convert.ToLong(object)
+string Convert.ToString(object)
+... etc
+```
+
+If desired, conversion failures can be ignored (it is left to the user to determine when this is wise), with or without a default fallback value:
+
+```C#
+object Force.To(object value, Type targetType);
+object Force.To(object value, Type targetType, object defaultValue);
+     T Force.To<T>(object value);
+     T Force.To<T>(object value, T defaultValue);
+```
+ 
+Finally, methods are provided to convert to and from `DBNull`, or detect a "null" value (with the user specifying which things should be considered null):
+
+```C#
+object Convert.ToNull(object)  // Converts DBNull to null, leaves other values as-is
+object Convert.ToDBNull(object)  // Converts null to DBNull, leaves other values as-is
+
+// More control over what is considered null:
+object Convert.ToNull(object value, ConvertOptions options) 
+object Convert.ToNull(object value, bool emptyStringAsNull) 
+object Convert.ToDBNull(object value, ConvertOptions options) 
+object Convert.ToDBNull(object value, bool emptyStringAsNull) 
+
+// Or to simply inspect:
+bool Value.IsNull(object value)     // True if null or DBNull
+bool Value.IsNull(object value, bool emptyStringAsNull)
+bool Value.IsNull(object value, ConvertOptions options)
+```
+
+Similar functions are provided on the `Converter` class, where they use whatever options have been configured on the converter instance:
+
+```C#
+// Where 'other empty value' is determined by the converter's ConvertOptions 
+converter.ToNull(value)    // Converts DBNull or other empty value to null
+converter.ToDBNull(value)  // Converts null or other empty value to DBNull
+converter.IsNull(value)    // Detects null, DBNull, or other empty value
+```
+
+## Customization
+ 
+A specific set of conversion options can be reused more easily with an instance of the `Converter` class
+
+```C#
+var options = ConvertOptionsBuilder.Create()
+  .WithEnumOptions(undefinedNames: UndefinedValueOption.Ignore)
+  .WithStringOptions(emptyStringOptions: EmptyStringConvertOptions.WhitespaceAsNull, allowHex: true)
+  .WithTrueStrings(bool.TrueString, 't', 'x', 'y')
+  .WithFalseStrings(bool.FalseString, 'f', '', 'x')
+  .Build();
+
+var converter = new Converter(options);
+
+// All of the following use the ConvertOptions used to construct the converter:
+converter.ToInt(value)  
+converter.To<int?>(value)
+converter.To(value, type)
+converter.Force<T>(value, T @default)
+... etc
+```
+
+`Converter`, `ConvertOptions`, and `ConvertOptionsBuilder` can all be subclassed. In addition, the base `Converter` class can be extended by registering converters for specific types by providing a method that can match `ConverterDelegate` or `ConverterDelegate<T>`:
+
+```C#
+var extendedConverter = converter
+  .WithConverter<bool>((value, options) => /* custom logic, replacing default */ );
+```
+
+# Purpose
+
+The Base Class Library and .NET languages themselves provide multiple ways to convert between primitive data types. So why is a separate library like this needed?
+
+The existing basic data conversions available from the [`System.Convert`](https://docs.microsoft.com/en-us/dotnet/api/system.convert) and [`Microsoft.VisualBasic.CompilerServices.Conversions`](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.VisualBasic.CompilerServices.Conversions) classes fail in several cases that arise frequently when working with serialization and deserialization:
+
+ - Converting to and from [`DBNull`](https://docs.microsoft.com/en-us/dotnet/api/system.dbnull)
+ - Converting to and from [`Nullable<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1) values
+ - Converting to and from [enumeration](https://docs.microsoft.com/en-us/dotnet/standard/base-types/common-type-system#Enumerations) types
+ - Converting to and from [`Guid`](https://docs.microsoft.com/en-us/dotnet/api/system.guid)s
+ - Converting to and from [`TimeSpan`](https://docs.microsoft.com/en-us/dotnet/api/system.timespan)
+ - Converting between [`Boolean`](https://docs.microsoft.com/en-us/dotnet/api/system.boolean) and the many string representations used in databases in the wild
+
+They also lack a universal conversion API with generic syntax. I.e. there is no `T Convert.To<T>(object value)` in the BCL. The two BCL universal converters are non-generic methods which require a runtime `Type` object and return an `object`:
+ - [`System.Convert.ChangeType`](https://docs.microsoft.com/en-us/dotnet/api/system.convert.changetype) 
+ - [`Conversions.ChangeType`](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.VisualBasic.CompilerServices.Conversions.ChangeType) , which is used by the [VB.NET](https://docs.microsoft.com/en-us/dotnet/visual-basic/) compiler to implement the [`CType` language function](https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/functions/ctype-function).
+ 
+## Differences in `System.Convert`, `Microsoft.VisualBasic.CompilerServices.Conversions`
+
+The two BCL converters also have important differences and notable behaviors: 
+
+- `System.Convert.ChangeType(object, Type)` will automatically use an applicable `IConvertible` interface method, but will **not** use [user-defined conversion operators](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/user-defined-conversion-operators) (`operator implicit` in C# / [`Widening Operator` in VB.NET](https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/operator-statement))
+- `Microsoft.VisualBasic.CompilerServices.Conversions.ChangeType(object, Type)` **will** use user-defined conversion operators but will **not** use `IConvertible`.
+- `System.Convert.ToInt32(null)` returns `0`, while `System.Convert.ChangeType(null, typeof(int))` throws an exception
+- `Microsoft.VisualBasic.CompilerServices.Conversions.Integer(null)` returns `0`, and `Microsoft.VisualBasic.CompilerServices.Conversions.ChangeType(null, typeof(int))` also returns `0`
+
+## Controlling subtleties of conversion
+
+Beyond the awkward `IFormatProvider` option which can be provided to `System.Convert`, the BCL conversions do not provide means of explicitly controlling conversion behaviors which must be considered when deserializing or converting from an external data source. This library exposes the following options as explicit choices:
+
+  - Treating an empty string as null (or not)
+  - Recognizing hexadecimal strings as numbers (or not)
+  - Converting null values to the default value of a value type (or not)
+  - Suppressing errors when attempting to convert, with or without an explicit fallback value (or not)
+ 
+## Dynamic Value Inspection
+
+The BCL also lacks succinct methods for checking if a value can be treated as numeric, if it is the default value of a value type (e.g `0` for any numeric type), or if it is null / empty / DBNull. These basic inspection actions are often required when validating or reasoning about input from external services or data sources.
+
+# Architecture
+
+The core conversion logic is implemented in the **internal** method `Ockham.Data.Convert.To`:
+
+```c#
+internal static object To(
+  object value, 
+  Type targetType, 
+  ConvertOptions options, 
+  bool ignoreError, 
+  object defaultValue,
+  bool customConverters,
+  Dictionary<Type, ConverterDelegate> converters
+)
+```
+
+The various overloads of `To*` and `Force*` on the static `Convert` class and configurable `Converter` class instances internally resolve to this single conversion logic, just with different variations of the input arguments, and sometimes with a direct cast to the required output type.
+
+The conversion logic does not replace built-in BCL conversion tools, but rather arranges and combines them into an efficient whole. It falls back to `System.Convert.ChangeType(object, Type)` if it detects an `IConvertible` input with a valid candidate output type, and falls back to `Microsoft.VisualBasic.CompilerServices.Conversions.ChangeType(object, Type)` for other basic conversions, which takes advantage of that implementation's advanced features such as automatic detection and use of user-defined conversion operators.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The utilities in this library provide robust, configurable data inspection and c
 
 # The API
 
-The most basic operation is to convert from a value of an unknown type (`object`) to a specific type, using either generic syntax (when you know the target type at compile time) or non-generic sytax (when you need to specify the target type at runtime):
+The most basic operation is to convert from a value of an unknown type (`object`) to a specific type, using either generic syntax (when you know the target type at compile time) or non-generic syntax (when you need to specify the target type at runtime):
 
 ```C#
 using Ockham.Data;

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ var options = ConvertOptionsBuilder.Create()
   .WithStringOptions(emptyStringOptions: EmptyStringConvertOptions.WhitespaceAsNull, allowHex: true)
   .WithTrueStrings(bool.TrueString, 't', 'x', 'y')
   .WithFalseStrings(bool.FalseString, 'f', '', 'x')
-  .Build();
+  .Options;
 
 var converter = new Converter(options);
 

--- a/api/lib/BoolConverter.cs
+++ b/api/lib/BoolConverter.cs
@@ -1,0 +1,7 @@
+﻿namespace Ockham.Data
+{
+    public static class BoolConverter
+    {
+        public static bool ToBool(object value, ConvertOptions options) => throw null;
+    }
+}

--- a/api/lib/Convert.cs
+++ b/api/lib/Convert.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Ockham.Data
+{ 
+    public static partial class Convert
+    {
+        public static object Force(object value, Type targetType) => throw null;
+        public static T Force<T>(object value) => throw null;
+        public static T Force<T>(object value, T defaultValue) => throw null;
+        public static T To<T>(object value) => throw null;
+        public static T To<T>(object value, ConvertOptions options) => throw null;
+        public static object To(object value, Type targetType) => throw null;
+        public static object To(object value, Type targetType, ConvertOptions options) => throw null;
+         
+        public static object ToNull(object value, bool emptyStringAsNull = true) => throw null;
+        public static object ToNull(object value, ConvertOptions options) => throw null;
+        public static object ToDBNull(object value, bool emptyStringAsNull = true) => throw null;
+        public static object ToDBNull(object value, ConvertOptions options) => throw null;
+    }
+
+    public static partial class Convert
+    { 
+        // These type-specific overloads use the ConvertOptions.Default set of options,
+        // which behave as close as possible to the applicable BCL utilities.
+        public static bool ToBool(object value) => throw null;
+        public static DateTime ToDate(object value) => throw null;
+        public static decimal ToDec(object value) => throw null;
+        public static double ToDbl(object value) => throw null;
+        public static Guid ToGuid(object value) => throw null;
+        public static int ToInt(object value) => throw null;
+        public static long ToLng(object value) => throw null;
+        public static string ToStr(object value) => throw null;
+        public static TimeSpan ToTimeSpan(object value) => throw null; 
+    }
+}

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -29,14 +29,14 @@ namespace Ockham.Data
 
     public class ConvertOptionsBuilder<T> where T : ConvertOptions
     {
-        public T Build() => throw null;
+        public T Options => throw null;
 
         public ConvertOptionsBuilder<T> WithStringOptions(EmptyStringConvertOptions emptyStringOptions, bool allowHex = false, bool trim = false) => throw null;
         public ConvertOptionsBuilder<T> WithBoolOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
         public ConvertOptionsBuilder<T> WithEnumOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) => throw null;
         public ConvertOptionsBuilder<T> WithValueTypeOptions(ValueTypeOptions valueTypeOptions) => throw null;
         public ConvertOptionsBuilder<T> WithTrueStrings(params string[] trueStrings) => throw null;
-        public ConvertOptionsBuilder<T> WithFlaseStrings(params string[] falseStrings) => throw null;
+        public ConvertOptionsBuilder<T> WithFalseStrings(params string[] falseStrings) => throw null;
     }
 
     public class ConvertOptionsBuilder : ConvertOptionsBuilder<ConvertOptions>

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ockham.Data
+{
+    // *Immutable* set of convert options
+    public class ConvertOptions
+    { 
+        // Default: Options that cause Ockham.Convert to behave as close as possible to the corresponding BCL functions.
+        // For example, Enum.Parse(type, string) throws an exception for an undefined enum *name*, but 
+        // Enum.ToObject(type, int) happily accepts an undefined enum *value*. And compiler mechanics 
+        // generally do NOT allow converting null to a value type, but do allow converting null to a
+        // Nullable<T> struct. Thus Convert.To<int>(null) should throw, but Convert.To<int?>(null) should be ok.
+        public static ConvertOptions Default { get; } 
+
+        public ConvertOptions(
+            StringConvertOptions stringOptions,
+            EnumConvertOptions enumOptions,
+            BooleanConvertOptions booleanOptions,
+            ValueTypeOptions valueTypeOptions
+        )
+        { }
+
+        public StringConvertOptions Strings { get; }
+        public EnumConvertOptions Enums { get; }
+        public BooleanConvertOptions Booleans { get; }
+        public ValueTypeOptions ValueTypes { get; }
+    }
+
+    public class ConvertOptionsBuilder<T> where T : ConvertOptions
+    {
+        public T Build() => throw null;
+
+        public ConvertOptionsBuilder<T> WithStringOptions(EmptyStringConvertOptions emptyStringOptions, bool allowHex = false, bool trim = false) => throw null;
+        public ConvertOptionsBuilder<T> WithBoolOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
+        public ConvertOptionsBuilder<T> WithEnumOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) => throw null;
+        public ConvertOptionsBuilder<T> WithValueTypeOptions(ValueTypeOptions valueTypeOptions) => throw null;
+        public ConvertOptionsBuilder<T> WithTrueStrings(params string[] trueStrings) => throw null;
+        public ConvertOptionsBuilder<T> WithFlaseStrings(params string[] falseStrings) => throw null;
+    }
+
+    public class ConvertOptionsBuilder : ConvertOptionsBuilder<ConvertOptions>
+    {
+        public static ConvertOptionsBuilder<T> Create<T>() where T : ConvertOptions => throw null;
+        public static ConvertOptionsBuilder Create() => throw null;
+    }
+
+    // *Immutable* set of string convert options
+    public class StringConvertOptions
+    {
+        public StringConvertOptions(EmptyStringConvertOptions emptyStringOptions, bool allowHex, bool trim) { }
+        public EmptyStringConvertOptions EmptyStrings { get; }
+        public bool Allow0xHex { get; }
+        public bool Trim { get; } // Trim strings before converting to other types
+    }
+
+    [Flags]
+    public enum EmptyStringConvertOptions
+    {
+        None = 0,
+        EmptyStringAsNull = 0x1,
+        WhitespaceAsNull = 0x2
+    }
+
+    // *Immutable* set of enum convert options
+    public class EnumConvertOptions
+    {
+        public EnumConvertOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) { }
+        public UndefinedValueOption UndefinedValues { get; }
+        public UndefinedValueOption UndefinedNames { get; }
+    }
+
+    // Options for how to handle undefined values during conversion, such as to an enum type
+    public enum UndefinedValueOption
+    {
+        Throw = 1,  // Throw an exception when an undefined value is encountered 
+        Ignore = 2, // Ignore and exclude from the output 
+        Coerce = 3  // If possible, coerce the source value to the target type, as <see cref="Enum.ToObject(Type, object)"/> does with enums
+    }
+
+    // *Immutable* set of bool convert options
+    public class BooleanConvertOptions
+    {
+        public ICollection<string> TrueStrings { get; }
+        public ICollection<string> FalseStrings { get; }
+    }
+
+    [Flags]
+    public enum ValueTypeOptions
+    {
+        None = 0,
+        NullToValueDefault = 0x1  // Convert null values to the default value when the target type is a value type
+    }
+}

--- a/api/lib/Converter.cs
+++ b/api/lib/Converter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ockham.Data
+{
+    public delegate object ConverterDelegate(object value, Type targetType, ConvertOptions options);
+    public delegate object ConverterDelegate<T>(object value, ConvertOptions options);
+
+    public partial class Converter
+    {
+        public static Converter Default { get; } = new Converter(ConvertOptions.Default);
+
+        public Converter(ConvertOptions options) => throw null;
+        public Converter(ConvertOptions options, params (Type targetType, ConverterDelegate @delegate)[] converters) => throw null;
+
+        public ConvertOptions Options { get; }
+
+        public object Force(object value, Type targetType) => throw null;
+        public T Force<T>(object value) => throw null;
+        public T Force<T>(object value, T defaultValue) => throw null;
+        public T To<T>(object value) => throw null;
+        public object To(object value, Type targetType) => throw null;
+
+        public bool IsNumeric(object value) => throw null;
+        public bool IsNull(object value) => throw null;
+        public object ToNull(object value) => throw null;
+        public object ToDBNull(object value) => throw null;
+
+        public IReadOnlyDictionary<Type, ConverterDelegate> Converters { get; }
+        public Converter WithConverter<T>(ConverterDelegate<T> @delegate) => throw null;
+        public Converter WithConverter(Type targetType, ConverterDelegate @delegate) => throw null;
+        public Converter WithConverters((Type targetType, ConverterDelegate @delegate) converter, params (Type targetType, ConverterDelegate @delegate)[] converters) => throw null;
+    }
+
+    public partial class Converter
+    {
+        public bool ToBool(object value) => throw null;
+        public DateTime ToDate(object value) => throw null;
+        public decimal ToDec(object value) => throw null;
+        public double ToDbl(object value) => throw null;
+        public Guid ToGuid(object value) => throw null;
+        public int ToInt(object value) => throw null;
+        public long ToLng(object value) => throw null;
+        public string ToStr(object value) => throw null;
+        public TimeSpan ToTimeSpan(object value) => throw null;
+    }
+}

--- a/api/lib/Converter.cs
+++ b/api/lib/Converter.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 
 namespace Ockham.Data
 {
-    public delegate object ConverterDelegate(object value, Type targetType, ConvertOptions options);
-    public delegate object ConverterDelegate<T>(object value, ConvertOptions options);
+    public delegate object ConverterDelegate(object value, ConvertOptions options);
+    public delegate T ConverterDelegate<T>(object value, ConvertOptions options);
 
     public partial class Converter
     {
@@ -43,5 +43,6 @@ namespace Ockham.Data
         public long ToLng(object value) => throw null;
         public string ToStr(object value) => throw null;
         public TimeSpan ToTimeSpan(object value) => throw null;
-    }
+    } 
 }
+

--- a/api/lib/GuidConverter.cs
+++ b/api/lib/GuidConverter.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ockham.Data
+{
+    public static class GuidConverter
+    {
+        public static Guid ToGuid(object value, ConvertOptions options) => throw null;
+    }
+}

--- a/api/lib/TimeSpanConverter.cs
+++ b/api/lib/TimeSpanConverter.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ockham.Data
+{
+    public static class TimeSpanConverter
+    {
+        public static TimeSpan ToTimeSpan(object value, ConvertOptions options) => throw null;
+    }
+}

--- a/api/lib/Value.cs
+++ b/api/lib/Value.cs
@@ -1,0 +1,14 @@
+﻿namespace Ockham.Data
+{ 
+    public static class Value
+    { 
+        public static bool IsNumeric(object value) => throw null;
+        public static bool IsNumeric(object value, ConvertOptions options) => throw null; 
+        public static bool IsDefault(object value) => throw null;
+        public static bool IsNull(object value) => throw null;
+        public static bool IsNull(object value, bool emptyStringAsNull) => throw null;
+        public static bool IsNull(object value, ConvertOptions options) => throw null;
+        public static bool IsNullOrEmpty(object value) => throw null;
+        public static bool IsNullOrWhitespace(object value) => throw null; 
+    }
+}


### PR DESCRIPTION
I've reworked this somewhat from the experimental version in https://github.com/ockham-net/exp-ockham.net.convert. Biggest changes:

- `ConvertOptions` is now decomposed into several immutable topical sections with associated enums and classes. A `ConvertOptionsBuilder` class is also provided to aid building up `ConvertOptions` instances, which are immutable
- There is a simple way to register custom conversion functions
- The type-specific implementations of `ToGuid`, `ToBool`, and `ToTimespan` have been separated out into their own static classes, where they can be invoked directly.
- The README has been thoroughly updated, and hopefully contributes to understanding the purpose of this proposed API