### PR TITLE
Clean up ConvertOptions and builder

### DIFF
--- a/Ockham.Convert.sln
+++ b/Ockham.Convert.sln
@@ -18,8 +18,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ockham.Convert.Tests", "tes
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "build", "build\build.shproj", "{C9EEE568-9891-4643-9D4D-4F67005D74A4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "results", "tests\results\results.csproj", "{867D8FB0-13CC-4EFA-A575-9157533C1A95}"
-EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Build\Build.projitems*{c9eee568-9891-4643-9d4d-4f67005d74a4}*SharedItemsImports = 13
@@ -41,10 +39,6 @@ Global
 		{BA287A39-F846-4355-8273-0F9CE17FA4C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA287A39-F846-4355-8273-0F9CE17FA4C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA287A39-F846-4355-8273-0F9CE17FA4C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{867D8FB0-13CC-4EFA-A575-9157533C1A95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{867D8FB0-13CC-4EFA-A575-9157533C1A95}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{867D8FB0-13CC-4EFA-A575-9157533C1A95}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{867D8FB0-13CC-4EFA-A575-9157533C1A95}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,7 +48,6 @@ Global
 		{FE23EB38-D56C-4B6F-BC45-43E9B7CCC95C} = {26BCD9A0-AA81-4415-AFCF-2194B8AE9C49}
 		{BA287A39-F846-4355-8273-0F9CE17FA4C3} = {7ED89FB2-29B6-49EE-990C-44842967A0D3}
 		{C9EEE568-9891-4643-9D4D-4F67005D74A4} = {3B0AEBAA-8E41-4543-9979-BD90AF2D05E8}
-		{867D8FB0-13CC-4EFA-A575-9157533C1A95} = {7ED89FB2-29B6-49EE-990C-44842967A0D3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F2E75385-1681-4D62-B833-7062B63987C4}

--- a/api/lib/ConvertOptions.Booleans.cs
+++ b/api/lib/ConvertOptions.Booleans.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Ockham.Data
+{
+    // *Immutable* set of bool convert options
+    public class BooleanConvertOptions : OptionSet
+    {
+        public BooleanConvertOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
+        public IReadOnlyCollection<string> TrueStrings { get; }
+        public IReadOnlyCollection<string> FalseStrings { get; }
+    }
+}

--- a/api/lib/ConvertOptions.Booleans.cs
+++ b/api/lib/ConvertOptions.Booleans.cs
@@ -6,6 +6,9 @@ namespace Ockham.Data
     // *Immutable* set of bool convert options
     public class BooleanConvertOptions : OptionSet
     {
+        // Settings that match BCL behavior
+        public static BooleanConvertOptions Default { get; }
+
         public BooleanConvertOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
         public IImmutableSet<string> TrueStrings { get; }
         public IImmutableSet<string> FalseStrings { get; }

--- a/api/lib/ConvertOptions.Booleans.cs
+++ b/api/lib/ConvertOptions.Booleans.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Ockham.Data
 {
@@ -6,7 +7,7 @@ namespace Ockham.Data
     public class BooleanConvertOptions : OptionSet
     {
         public BooleanConvertOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
-        public IReadOnlyCollection<string> TrueStrings { get; }
-        public IReadOnlyCollection<string> FalseStrings { get; }
+        public IImmutableSet<string> TrueStrings { get; }
+        public IImmutableSet<string> FalseStrings { get; }
     }
 }

--- a/api/lib/ConvertOptions.Builder.cs
+++ b/api/lib/ConvertOptions.Builder.cs
@@ -8,6 +8,9 @@ namespace Ockham.Data
         // Intialize with empty options
         public static ConvertOptionsBuilder Empty => throw null;
 
+        // Initialize with default options
+        public static ConvertOptionsBuilder Default => throw null;
+
         // Initialize from existing ConvertOptions
         public static ConvertOptionsBuilder FromConvertOptions(ConvertOptions source) => throw null;
 

--- a/api/lib/ConvertOptions.Builder.cs
+++ b/api/lib/ConvertOptions.Builder.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Ockham.Data
+{
+    public class ConvertOptionsBuilder : IEnumerable<OptionSet>
+    {
+        // Intialize with empty options
+        public static ConvertOptionsBuilder Empty => throw null;
+
+        // Initialize from existing ConvertOptions
+        public static ConvertOptionsBuilder FromConvertOptions(ConvertOptions source) => throw null;
+
+        public ConvertOptionsBuilder() => throw null;
+        public ConvertOptionsBuilder(IEnumerable<OptionSet> options) => throw null;
+        public ConvertOptionsBuilder(IEnumerable<OptionSet> options, OptionSet newOptions) => throw null;
+
+        public ConvertOptions Options { get; }
+
+        public T GetOptions<T>() where T : OptionSet => throw null;
+
+        public ConvertOptionsBuilder WithBoolOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
+        public ConvertOptionsBuilder WithTrueStrings(params string[] trueStrings) => throw null;
+        public ConvertOptionsBuilder WithFalseStrings(params string[] falseStrings) => throw null;
+        public ConvertOptionsBuilder WithEnumOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) => throw null;
+        public ConvertOptionsBuilder WithNumberOptions(ParseNumericStringFlags parseFlags) => throw null;
+        public ConvertOptionsBuilder WithStringOptions(StringAsNullOption asNullOption, TrimStringFlags trimFlags) => throw null;
+        public ConvertOptionsBuilder WithValueTypeOptions(ValueTypeConvertFlags convertFlags) => throw null;
+        public ConvertOptionsBuilder WithOptions(OptionSet options) => throw null;
+
+        public IEnumerator<OptionSet> GetEnumerator() => throw null;
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+}

--- a/api/lib/ConvertOptions.Enums.cs
+++ b/api/lib/ConvertOptions.Enums.cs
@@ -3,6 +3,9 @@
     // *Immutable* set of enum convert options
     public class EnumConvertOptions : OptionSet
     {
+        // Settings that match BCL behavior
+        public static EnumConvertOptions Default { get; }
+
         public EnumConvertOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) { }
         public UndefinedValueOption UndefinedValues { get; }
         public UndefinedValueOption UndefinedNames { get; }

--- a/api/lib/ConvertOptions.Enums.cs
+++ b/api/lib/ConvertOptions.Enums.cs
@@ -1,0 +1,22 @@
+﻿namespace Ockham.Data
+{
+    // *Immutable* set of enum convert options
+    public class EnumConvertOptions : OptionSet
+    {
+        public EnumConvertOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) { }
+        public UndefinedValueOption UndefinedValues { get; }
+        public UndefinedValueOption UndefinedNames { get; }
+
+        public bool IgnoreUndefinedValues { get; }
+        public bool CoerceUndefinedValues { get; }
+        public bool IgnoreUndefinedNames { get; }
+    }
+
+    // Options for how to handle undefined values during conversion, such as to an enum type
+    public enum UndefinedValueOption
+    {
+        Throw = 1,  // Throw an exception when an undefined value is encountered 
+        Ignore = 2, // Ignore and exclude from the output 
+        Coerce = 3  // If possible, coerce the source value to the target type, as <see cref="Enum.ToObject(Type, object)"/> does with enums
+    }
+}

--- a/api/lib/ConvertOptions.Numbers.cs
+++ b/api/lib/ConvertOptions.Numbers.cs
@@ -5,6 +5,9 @@ namespace Ockham.Data
     // *Immutable* set of bool convert options
     public class NumberConvertOptions : OptionSet
     {
+        // Settings that match BCL behavior
+        public static NumberConvertOptions Default { get; }
+
         public NumberConvertOptions(ParseNumericStringFlags parseFlags) => throw null;
 
         public ParseNumericStringFlags ParseFlags { get; }

--- a/api/lib/ConvertOptions.Numbers.cs
+++ b/api/lib/ConvertOptions.Numbers.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Ockham.Data
+{
+    // *Immutable* set of bool convert options
+    public class NumberConvertOptions : OptionSet
+    {
+        public NumberConvertOptions(ParseNumericStringFlags parseFlags) => throw null;
+
+        public ParseNumericStringFlags ParseFlags { get; }
+
+        public bool ParseHex => ParseFlags.HasFlag(ParseNumericStringFlags.HexString);
+        public bool ParseOctal => ParseFlags.HasFlag(ParseNumericStringFlags.OctalString);
+        public bool ParseBinary => ParseFlags.HasFlag(ParseNumericStringFlags.BinaryString);
+        public bool IgnoreDigitSeparator => ParseFlags.HasFlag(ParseNumericStringFlags.IgnoreDigitSeparator);
+    }
+
+    [Flags]
+    public enum ParseNumericStringFlags
+    {
+        None = 0x0,
+        HexString = 0x1,
+        OctalString = 0x2,
+        BinaryString = 0x4,
+        IgnoreDigitSeparator = 0x10
+    }
+}

--- a/api/lib/ConvertOptions.Numbers.cs
+++ b/api/lib/ConvertOptions.Numbers.cs
@@ -12,7 +12,7 @@ namespace Ockham.Data
         public bool ParseHex => ParseFlags.HasFlag(ParseNumericStringFlags.HexString);
         public bool ParseOctal => ParseFlags.HasFlag(ParseNumericStringFlags.OctalString);
         public bool ParseBinary => ParseFlags.HasFlag(ParseNumericStringFlags.BinaryString);
-        public bool IgnoreDigitSeparator => ParseFlags.HasFlag(ParseNumericStringFlags.IgnoreDigitSeparator);
+        public bool AllowDigitSeparator => ParseFlags.HasFlag(ParseNumericStringFlags.AllowDigitSeparator);
     }
 
     [Flags]
@@ -22,6 +22,6 @@ namespace Ockham.Data
         HexString = 0x1,
         OctalString = 0x2,
         BinaryString = 0x4,
-        IgnoreDigitSeparator = 0x10
+        AllowDigitSeparator = 0x10
     }
 }

--- a/api/lib/ConvertOptions.Strings.cs
+++ b/api/lib/ConvertOptions.Strings.cs
@@ -5,6 +5,9 @@ namespace Ockham.Data
     // *Immutable* set of string convert options
     public class StringConvertOptions : OptionSet
     {
+        // Settings that match BCL behavior
+        public static StringConvertOptions Default { get; }
+
         public StringConvertOptions(StringAsNullOption asNullOption, TrimStringFlags trimFlags) { }
         public StringAsNullOption AsNullOption { get; }
         public TrimStringFlags TrimFlags { get; }
@@ -32,5 +35,5 @@ namespace Ockham.Data
         TrimStart = 0x1,
         TrimEnd = 0x2,
         TrimAll = 0x3
-    } 
+    }
 }

--- a/api/lib/ConvertOptions.Strings.cs
+++ b/api/lib/ConvertOptions.Strings.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Ockham.Data
+{
+    // *Immutable* set of string convert options
+    public class StringConvertOptions : OptionSet
+    {
+        public StringConvertOptions(StringAsNullOption asNullOption, TrimStringFlags trimFlags) { }
+        public StringAsNullOption AsNullOption { get; }
+        public TrimStringFlags TrimFlags { get; }
+
+        public bool WhitespaceAsNull => AsNullOption >= StringAsNullOption.Whitespace;
+        public bool EmptyStringAsNull => AsNullOption >= StringAsNullOption.EmptyString;
+
+        public bool TrimNone => TrimFlags == TrimStringFlags.None;
+        public bool TrimStart => TrimFlags.HasFlag(TrimStringFlags.TrimStart);
+        public bool TrimEnd => TrimFlags.HasFlag(TrimStringFlags.TrimEnd);
+        public bool TrimAll => TrimFlags.HasFlag(TrimStringFlags.TrimAll);
+    }
+
+    public enum StringAsNullOption
+    {
+        NullReference = 0,
+        EmptyString = 1,
+        Whitespace = 2
+    }
+
+    [Flags]
+    public enum TrimStringFlags
+    {
+        None = 0,
+        TrimStart = 0x1,
+        TrimEnd = 0x2,
+        TrimAll = 0x3
+    } 
+}

--- a/api/lib/ConvertOptions.Values.cs
+++ b/api/lib/ConvertOptions.Values.cs
@@ -5,6 +5,9 @@ namespace Ockham.Data
 
     public class ValueTypeOptions : OptionSet
     {
+        // Settings that match BCL behavior
+        public static ValueTypeOptions Default { get; }
+
         public ValueTypeOptions(ValueTypeConvertFlags convertFlags) => throw null;
         public ValueTypeConvertFlags ConvertFlags { get; }
 

--- a/api/lib/ConvertOptions.Values.cs
+++ b/api/lib/ConvertOptions.Values.cs
@@ -3,12 +3,12 @@
 namespace Ockham.Data
 {
 
-    public class ValueTypeOptions : OptionSet
+    public class ValueTypeConvertOptions : OptionSet
     {
         // Settings that match BCL behavior
-        public static ValueTypeOptions Default { get; }
+        public static ValueTypeConvertOptions Default { get; }
 
-        public ValueTypeOptions(ValueTypeConvertFlags convertFlags) => throw null;
+        public ValueTypeConvertOptions(ValueTypeConvertFlags convertFlags) => throw null;
         public ValueTypeConvertFlags ConvertFlags { get; }
 
         public bool NullToValueDefault => ConvertFlags.HasFlag(ValueTypeConvertFlags.NullToValueDefault);

--- a/api/lib/ConvertOptions.Values.cs
+++ b/api/lib/ConvertOptions.Values.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Ockham.Data
+{
+
+    public class ValueTypeOptions : OptionSet
+    {
+        public ValueTypeOptions(ValueTypeConvertFlags convertFlags) => throw null;
+        public ValueTypeConvertFlags ConvertFlags { get; }
+
+        public bool NullToValueDefault => ConvertFlags.HasFlag(ValueTypeConvertFlags.NullToValueDefault);
+    }
+
+    [Flags]
+    public enum ValueTypeConvertFlags
+    {
+        None = 0,
+        NullToValueDefault = 0x1  // Convert null values to the default value when the target type is a value type
+    }
+}

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -18,7 +18,7 @@ namespace Ockham.Data
             EnumConvertOptions enumOptions,
             NumberConvertOptions numberOptions,
             StringConvertOptions stringOptions,
-            ValueTypeOptions valueTypeOptions,
+            ValueTypeConvertOptions valueTypeOptions,
             params OptionSet[] otherOptions
         ) : this((new OptionSet[] { booleanOptions, enumOptions, numberOptions, stringOptions, valueTypeOptions }).Concat(otherOptions)) { }
 
@@ -29,7 +29,7 @@ namespace Ockham.Data
         public EnumConvertOptions Enums { get; }
         public NumberConvertOptions Numbers { get; }
         public StringConvertOptions Strings { get; }
-        public ValueTypeOptions ValueTypes { get; }
+        public ValueTypeConvertOptions ValueTypes { get; }
 
         public T GetOptions<T>() where T : OptionSet => throw null;
 

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -1,94 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Ockham.Data
 {
     // *Immutable* set of convert options
     public class ConvertOptions
-    { 
+    {
         // Default: Options that cause Ockham.Convert to behave as close as possible to the corresponding BCL functions.
         // For example, Enum.Parse(type, string) throws an exception for an undefined enum *name*, but 
         // Enum.ToObject(type, int) happily accepts an undefined enum *value*. And compiler mechanics 
         // generally do NOT allow converting null to a value type, but do allow converting null to a
         // Nullable<T> struct. Thus Convert.To<int>(null) should throw, but Convert.To<int?>(null) should be ok.
-        public static ConvertOptions Default { get; } 
+        public static ConvertOptions Default { get; }
 
         public ConvertOptions(
-            StringConvertOptions stringOptions,
-            EnumConvertOptions enumOptions,
             BooleanConvertOptions booleanOptions,
-            ValueTypeOptions valueTypeOptions
-        )
-        { }
+            EnumConvertOptions enumOptions,
+            NumberConvertOptions numberOptions,
+            StringConvertOptions stringOptions,
+            ValueTypeOptions valueTypeOptions,
+            params OptionSet[] otherOptions
+        ) : this((new OptionSet[] { booleanOptions, enumOptions, numberOptions, stringOptions, valueTypeOptions }).Concat(otherOptions)) { }
 
-        public StringConvertOptions Strings { get; }
-        public EnumConvertOptions Enums { get; }
+        public ConvertOptions(params OptionSet[] options) : this((IEnumerable<OptionSet>)options) { }
+        public ConvertOptions(IEnumerable<OptionSet> options) { }
+
         public BooleanConvertOptions Booleans { get; }
+        public EnumConvertOptions Enums { get; }
+        public NumberConvertOptions Numbers { get; }
+        public StringConvertOptions Strings { get; }
         public ValueTypeOptions ValueTypes { get; }
+
+        public T GetOptions<T>() where T : OptionSet => throw null; 
     }
 
-    public class ConvertOptionsBuilder<T> where T : ConvertOptions
-    {
-        public T Options => throw null;
-
-        public ConvertOptionsBuilder<T> WithStringOptions(EmptyStringConvertOptions emptyStringOptions, bool allowHex = false, bool trim = false) => throw null;
-        public ConvertOptionsBuilder<T> WithBoolOptions(IEnumerable<string> trueStrings, IEnumerable<string> falseStrings) => throw null;
-        public ConvertOptionsBuilder<T> WithEnumOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) => throw null;
-        public ConvertOptionsBuilder<T> WithValueTypeOptions(ValueTypeOptions valueTypeOptions) => throw null;
-        public ConvertOptionsBuilder<T> WithTrueStrings(params string[] trueStrings) => throw null;
-        public ConvertOptionsBuilder<T> WithFalseStrings(params string[] falseStrings) => throw null;
-    }
-
-    public class ConvertOptionsBuilder : ConvertOptionsBuilder<ConvertOptions>
-    {
-        public static ConvertOptionsBuilder<T> Create<T>() where T : ConvertOptions => throw null;
-        public static ConvertOptionsBuilder Create() => throw null;
-    }
-
-    // *Immutable* set of string convert options
-    public class StringConvertOptions
-    {
-        public StringConvertOptions(EmptyStringConvertOptions emptyStringOptions, bool allowHex, bool trim) { }
-        public EmptyStringConvertOptions EmptyStrings { get; }
-        public bool Allow0xHex { get; }
-        public bool Trim { get; } // Trim strings before converting to other types
-    }
-
-    [Flags]
-    public enum EmptyStringConvertOptions
-    {
-        None = 0,
-        EmptyStringAsNull = 0x1,
-        WhitespaceAsNull = 0x2
-    }
-
-    // *Immutable* set of enum convert options
-    public class EnumConvertOptions
-    {
-        public EnumConvertOptions(UndefinedValueOption undefinedNames, UndefinedValueOption undefinedValues) { }
-        public UndefinedValueOption UndefinedValues { get; }
-        public UndefinedValueOption UndefinedNames { get; }
-    }
-
-    // Options for how to handle undefined values during conversion, such as to an enum type
-    public enum UndefinedValueOption
-    {
-        Throw = 1,  // Throw an exception when an undefined value is encountered 
-        Ignore = 2, // Ignore and exclude from the output 
-        Coerce = 3  // If possible, coerce the source value to the target type, as <see cref="Enum.ToObject(Type, object)"/> does with enums
-    }
-
-    // *Immutable* set of bool convert options
-    public class BooleanConvertOptions
-    {
-        public ICollection<string> TrueStrings { get; }
-        public ICollection<string> FalseStrings { get; }
-    }
-
-    [Flags]
-    public enum ValueTypeOptions
-    {
-        None = 0,
-        NullToValueDefault = 0x1  // Convert null values to the default value when the target type is a value type
-    }
+    public abstract class OptionSet { }
 }

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -31,7 +31,9 @@ namespace Ockham.Data
         public StringConvertOptions Strings { get; }
         public ValueTypeOptions ValueTypes { get; }
 
-        public T GetOptions<T>() where T : OptionSet => throw null; 
+        public T GetOptions<T>() where T : OptionSet => throw null;
+
+        public IEnumerable<OptionSet> AllOptions() => throw null;
     }
 
     public abstract class OptionSet { }

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -32,6 +32,8 @@ namespace Ockham.Data
         public ValueTypeConvertOptions ValueTypes { get; }
 
         public T GetOptions<T>() where T : OptionSet => throw null;
+        public bool TryGetOptions<T>(out T optionSet) where T : OptionSet => throw null;
+        public bool HasOptions<T>() where T : OptionSet => throw null;
 
         public IEnumerable<OptionSet> AllOptions() => throw null;
     }

--- a/api/lib/Converter.cs
+++ b/api/lib/Converter.cs
@@ -29,7 +29,7 @@ namespace Ockham.Data
         public IReadOnlyDictionary<Type, ConverterDelegate> Converters { get; }
         public Converter WithConverter<T>(ConverterDelegate<T> @delegate) => throw null;
         public Converter WithConverter(Type targetType, ConverterDelegate @delegate) => throw null;
-        public Converter WithConverters((Type targetType, ConverterDelegate @delegate) converter, params (Type targetType, ConverterDelegate @delegate)[] converters) => throw null;
+        public Converter WithConverters(params (Type targetType, ConverterDelegate @delegate)[] converters) => throw null;
     }
 
     public partial class Converter

--- a/api/lib/Ockham.Convert.csproj
+++ b/api/lib/Ockham.Convert.csproj
@@ -6,9 +6,5 @@
   </PropertyGroup>
   
   <Import Project="..\..\build\assembly\Properties.csproj" />
-  
-  <ItemGroup>
-    <Compile Remove="Converter.cs" />
-  </ItemGroup>
 
 </Project>

--- a/api/lib/Ockham.Convert.csproj
+++ b/api/lib/Ockham.Convert.csproj
@@ -3,8 +3,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>1701;1702;1705;CS1591;IDE0060</NoWarn>
+    <AssemblyName>Ockham.Convert.API</AssemblyName>
   </PropertyGroup>
   
   <Import Project="..\..\build\assembly\Properties.csproj" />
+  
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/api/lib/Value.cs
+++ b/api/lib/Value.cs
@@ -3,7 +3,8 @@
     public static class Value
     { 
         public static bool IsNumeric(object value) => throw null;
-        public static bool IsNumeric(object value, ConvertOptions options) => throw null; 
+        public static bool IsNumeric(object value, ConvertOptions options) => throw null;
+        public static bool IsNumeric(object value, ParseNumericStringFlags parseFlags) => throw null;
         public static bool IsDefault(object value) => throw null;
         public static bool IsNull(object value) => throw null;
         public static bool IsNull(object value, bool emptyStringAsNull) => throw null;

--- a/build/assembly/Properties.csproj
+++ b/build/assembly/Properties.csproj
@@ -63,6 +63,7 @@
 
   <PropertyGroup Condition="('$(Configuration)' == 'Debug') AND ('$(ReleaseMode)' != 'Release')">
     <PackageVersion>$(FileVersion)-rc$(MinorBuildVersion)-debug</PackageVersion>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <!-- Doc file -->


### PR DESCRIPTION
The fundamental change here is to make `ConvertOptions` and `ConvertOptionsBuilder` really be an immutable dictionary of `Type` to some options instance. This means they can both be extended without inheriting; rather consumers can just add some arbitrary options set to the collection.

It does enforce two rules: That any new option sets must inherit from the empty `OptionSet` class, and that within a single collection there can only be one instance of each type. In other words, internally `ConvertOptions` is a `Dictionary<Type, OptionSet>`.  

The dictionary itself is not exposed on the public API, rather `ConvertOptions` and `ConvertOptions` both have a method `GetOptions<T>() where T : OptionSet` which will return the requested option set, if found, and cast it to the applicable type. 

This also makes it very easy to extend `ConvertOptions` and `ConvertOptionsBuilder` with extension methods. Here for example, is defining a new `ComplexNumberConvertOptions` class and making it visible on both `ConvertOptions` and `ConvertOptionsBuilder`:

```C#
public class ComplexNumberConvertOptions : OptionSet {
    public ComplexNumberConvertOptions(ComplexNumberElement convertToFlags) {
        this.ConvertToFlags = convertToFlags;
    }
    public ComplexNumberElement ConvertToFlags { get; }

    // Do not convert plain numbers to ComplexNumber
    public bool DoNotConvert => ConvertToFlags == ComplexNumberElement.None;

    // Convert plain number as real part of ComplexNumber
    public bool ToReal => ConvertToFlags == ComplexNumberElement.Real;

    // Convert plain number as imaginary part of ComplexNumber
    public bool ToImaginary => ConvertToFlags == ComplexNumberElement.Imaginary;
}

[Flags]
public enum ComplexNumberElement {
    None = 0x0,
    Real = 0x1,
    Imaginary = 0x2
}

public static class ComplexNumberConvertOptionsExtensions {

    // allows options.ComplexNumbers()
    public static ComplexNumberConvertOptions ComplexNumbers(this ConvertOptions options)
        => options.GetOptions<ComplexNumberConvertOptions>();

    // allows build.WithComplexNumberOptions(...)
    public static ConvertOptionsBuilder WithComplexNumberOptions(
        this ConvertOptionsBuilder builder, 
        ComplexNumberElement convertToFlags
    ) => new ConvertOptionsBuilder(builder, new ComplexNumberConvertOptions(convertToFlags));
}
```

## Number options
I removed the `Allow0xHex` property from `StringConvertOptions` and created a separate `NumberConvertOptions` with multiple flags for parsing hex, octal, or binary strings, and the option to ignore an embedded digit separator (`_`)

## Bool flags
Where applicable, I also added memoized boolean flag properties on individual option sets