### PR TITLE
Proposal/api update

### DIFF
--- a/api/lib/Convert.cs
+++ b/api/lib/Convert.cs
@@ -22,14 +22,14 @@ namespace Ockham.Data
     { 
         // These type-specific overloads use the ConvertOptions.Default set of options,
         // which behave as close as possible to the applicable BCL utilities.
-        public static bool ToBool(object value) => throw null;
-        public static DateTime ToDate(object value) => throw null;
-        public static decimal ToDec(object value) => throw null;
-        public static double ToDbl(object value) => throw null;
+        public static bool ToBoolean(object value) => throw null;
+        public static DateTime ToDateTime(object value) => throw null;
+        public static decimal ToDecimal(object value) => throw null;
+        public static double ToDouble(object value) => throw null;
         public static Guid ToGuid(object value) => throw null;
-        public static int ToInt(object value) => throw null;
-        public static long ToLng(object value) => throw null;
-        public static string ToStr(object value) => throw null;
+        public static int ToInt32(object value) => throw null;
+        public static long ToInt64(object value) => throw null;
+        public static string ToString(object value) => throw null;
         public static TimeSpan ToTimeSpan(object value) => throw null; 
     }
 }

--- a/api/lib/ConvertOptions.Builder.cs
+++ b/api/lib/ConvertOptions.Builder.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Ockham.Data
 {
     public class ConvertOptionsBuilder : IEnumerable<OptionSet>
     {
-        // Intialize with empty options
+        // Initialize with empty options
         public static ConvertOptionsBuilder Empty => throw null;
 
         // Initialize with default options
@@ -13,10 +14,6 @@ namespace Ockham.Data
 
         // Initialize from existing ConvertOptions
         public static ConvertOptionsBuilder FromConvertOptions(ConvertOptions source) => throw null;
-
-        public ConvertOptionsBuilder() => throw null;
-        public ConvertOptionsBuilder(IEnumerable<OptionSet> options) => throw null;
-        public ConvertOptionsBuilder(IEnumerable<OptionSet> options, OptionSet newOptions) => throw null;
 
         public ConvertOptions Options { get; }
 
@@ -29,10 +26,20 @@ namespace Ockham.Data
         public ConvertOptionsBuilder WithNumberOptions(ParseNumericStringFlags parseFlags) => throw null;
         public ConvertOptionsBuilder WithStringOptions(StringAsNullOption asNullOption, TrimStringFlags trimFlags) => throw null;
         public ConvertOptionsBuilder WithValueTypeOptions(ValueTypeConvertFlags convertFlags) => throw null;
-        public ConvertOptionsBuilder WithOptions(OptionSet options) => throw null;
+        public ConvertOptionsBuilder WithOptions(params OptionSet[] options) => throw null;
 
+        public ConvertOptionsBuilder WithConverter<T>(ConverterDelegate<T> @delegate) => throw null;
+        public ConvertOptionsBuilder WithConverter(Type targetType, ConverterDelegate @delegate) => throw null;
+        public ConvertOptionsBuilder WithoutConverters() => throw null;                     // Remove all custom conveters
+        public ConvertOptionsBuilder WithoutConverters(params Type[] types) => throw null;  // Remove custom conveters of specific types
+        public ConvertOptionsBuilder WithoutConverter<T>() => throw null;                   // Remove custom converter of type T
+
+        public IReadOnlyDictionary<Type, ConverterDelegate> Converters { get; }
         public IEnumerator<OptionSet> GetEnumerator() => throw null;
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        // Constructor is private. Use ConvertOptionsBuilder.Empty
+        private ConvertOptionsBuilder() => throw null;
     }
 
 }

--- a/api/lib/ConvertOptions.Builder.cs
+++ b/api/lib/ConvertOptions.Builder.cs
@@ -29,7 +29,6 @@ namespace Ockham.Data
         public ConvertOptionsBuilder WithOptions(params OptionSet[] options) => throw null;
 
         public ConvertOptionsBuilder WithConverter<T>(ConverterDelegate<T> @delegate) => throw null;
-        public ConvertOptionsBuilder WithConverter(Type targetType, ConverterDelegate @delegate) => throw null;
         public ConvertOptionsBuilder WithoutConverters() => throw null;                     // Remove all custom conveters
         public ConvertOptionsBuilder WithoutConverters(params Type[] types) => throw null;  // Remove custom conveters of specific types
         public ConvertOptionsBuilder WithoutConverter<T>() => throw null;                   // Remove custom converter of type T

--- a/api/lib/ConvertOptions.cs
+++ b/api/lib/ConvertOptions.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Ockham.Data
 {
@@ -12,24 +12,17 @@ namespace Ockham.Data
         // generally do NOT allow converting null to a value type, but do allow converting null to a
         // Nullable<T> struct. Thus Convert.To<int>(null) should throw, but Convert.To<int?>(null) should be ok.
         public static ConvertOptions Default { get; }
-
-        public ConvertOptions(
-            BooleanConvertOptions booleanOptions,
-            EnumConvertOptions enumOptions,
-            NumberConvertOptions numberOptions,
-            StringConvertOptions stringOptions,
-            ValueTypeConvertOptions valueTypeOptions,
-            params OptionSet[] otherOptions
-        ) : this((new OptionSet[] { booleanOptions, enumOptions, numberOptions, stringOptions, valueTypeOptions }).Concat(otherOptions)) { }
-
-        public ConvertOptions(params OptionSet[] options) : this((IEnumerable<OptionSet>)options) { }
-        public ConvertOptions(IEnumerable<OptionSet> options) { }
+         
+        public ConvertOptions(IEnumerable<OptionSet> options) => throw null;
+        public ConvertOptions(IEnumerable<OptionSet> options, IReadOnlyDictionary<Type, ConverterDelegate> converters) => throw null;
 
         public BooleanConvertOptions Booleans { get; }
         public EnumConvertOptions Enums { get; }
         public NumberConvertOptions Numbers { get; }
         public StringConvertOptions Strings { get; }
         public ValueTypeConvertOptions ValueTypes { get; }
+
+        public IReadOnlyDictionary<Type, ConverterDelegate> Converters { get; }
 
         public T GetOptions<T>() where T : OptionSet => throw null;
         public bool TryGetOptions<T>(out T optionSet) where T : OptionSet => throw null;

--- a/api/lib/Converter.cs
+++ b/api/lib/Converter.cs
@@ -11,7 +11,6 @@ namespace Ockham.Data
         public static Converter Default { get; } = new Converter(ConvertOptions.Default);
 
         public Converter(ConvertOptions options) => throw null;
-        public Converter(ConvertOptions options, params (Type targetType, ConverterDelegate @delegate)[] converters) => throw null;
 
         public ConvertOptions Options { get; }
 
@@ -25,11 +24,6 @@ namespace Ockham.Data
         public bool IsNull(object value) => throw null;
         public object ToNull(object value) => throw null;
         public object ToDBNull(object value) => throw null;
-
-        public IReadOnlyDictionary<Type, ConverterDelegate> Converters { get; }
-        public Converter WithConverter<T>(ConverterDelegate<T> @delegate) => throw null;
-        public Converter WithConverter(Type targetType, ConverterDelegate @delegate) => throw null;
-        public Converter WithConverters(params (Type targetType, ConverterDelegate @delegate)[] converters) => throw null;
     }
 
     public partial class Converter

--- a/api/lib/Converter.cs
+++ b/api/lib/Converter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Ockham.Data
 {
@@ -28,14 +27,14 @@ namespace Ockham.Data
 
     public partial class Converter
     {
-        public bool ToBool(object value) => throw null;
-        public DateTime ToDate(object value) => throw null;
-        public decimal ToDec(object value) => throw null;
-        public double ToDbl(object value) => throw null;
+        public bool ToBoolean(object value) => throw null;
+        public DateTime ToDateTime(object value) => throw null;
+        public decimal ToDecimal(object value) => throw null;
+        public double ToDouble(object value) => throw null;
         public Guid ToGuid(object value) => throw null;
-        public int ToInt(object value) => throw null;
-        public long ToLng(object value) => throw null;
-        public string ToStr(object value) => throw null;
+        public int ToInt32(object value) => throw null;
+        public long ToInt64(object value) => throw null;
+        public string ToString(object value) => throw null;
         public TimeSpan ToTimeSpan(object value) => throw null;
     } 
 }


### PR DESCRIPTION
This proposal includes two changes:

## Move custom converters to `ConvertOptions`
All along I've felt a little uneasy about having most customizations on `ConvertOptions`...but then the custom converter functions on `Converter`. Working through the unit tests I confirmed this introduces some awkwardness and confusion. `ConvertOptions` *should* be the fully self-contained collection of customizations, such that:

```C#
ConvertOptions options = ..(some options);

// This:
Convert.To<ExampleEnum>(someValue, options);

// Always works exactly the same as this:
(new Converter(options)).To<ExampleEnum>(someValue);
```
So this proposal removes the `Converters` dictionary and associated builder functions (`WithConverter...`) from `Converter`. The dictionary goes to `ConvertOptions`, and the builder functions go to `ConvertOptionsBuilder` along with all the rest of the fluid builder API.

Finally, because `ConvertOptionsBuilder` should be the one place to build up the configuration, I simplified the constructors on `ConvertOptions` and `Converter`. 

## Update conversion function names to match `System.Convert`
The ancestor work of this library was written years ago for a team that used mostly VB.Net. Following VB.Net idioms, we also imported the members of the `Convert` class such that we could use the functions with bare names, just like built-in language functions. In that ancestor library, the naming convention was `VInt`, `VLng`, etc, instead of `ToInt`, `ToLng`, etc:

```vb
Imports ACompany.Data 

Dim row As DataRow = (get row)...
Dim user As New User With {
    ID       = VInt(row("UserID")),
    UserName = VStr(row("UserName")),
    ... etc ...
}
```

These names echoed the VB language conversion functions `CBool`, `CDbl`, `CDec`, `CLng`, etc. When I introduced the `To` semantics, we still kept the VB idiom abbreviations, so we had `ToBool`, `ToDbl`, `ToDec`, etc. To developers working primarily in VB these may still seem familiar, but they do not match the naming convention established on `System.Convert`.

This proposal updates the names of the applicable functions to match the conventions in `System.Convert`:

```
ToBool => ToBoolean
ToInt  => ToInt32
ToLng  => ToInt64
... etc ...
```